### PR TITLE
2023.07.18 bbot build

### DIFF
--- a/lib/bbot-build-ub1604-64b.sh
+++ b/lib/bbot-build-ub1604-64b.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cp depspath.pri.bbot depspath.pri
+git clone https://gitlab.netresults.dev:10443/netresults/utils/scripts.git
+python3 scripts/wrappergen2/wrappergen.py -c nrpycpp_wrapper_conf.json
+qmake-5157
+make
+

--- a/lib/bbot-build-ub1604-64b.sh
+++ b/lib/bbot-build-ub1604-64b.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cp depspath.pri.bbot depspath.pri
-git clone https://gitlab.netresults.dev:10443/netresults/utils/scripts.git
+git clone https://nrbuilder:nrbbotpwd.@gitlab.netresults.dev:10443/netresults/utils/scripts.git
 python3 scripts/wrappergen2/wrappergen.py -c nrpycpp_wrapper_conf.json
 qmake-5157
 make

--- a/lib/depspath.pri.bbot
+++ b/lib/depspath.pri.bbot
@@ -1,0 +1,16 @@
+#define the following variables
+#PYTHON_LIB_PATH = path/to/python/libs
+#PYTHON_INCLUDE_PATH = path/to/python/includes
+#PYTHON_VERSION = the version of python used (for mac we need python3)
+
+#linux usual defaults
+PYTHON_VERSION=3.9
+PYTHON_LIB_PATH     = /usr/lib/python$${PYTHON_VERSION}
+PYTHON_INCLUDE_PATH = /usr/include/python$${PYTHON_VERSION}
+
+#xcode usual defaults (the 2.7 distributed on every mac as runtime lacks build libraries)
+#PYTHON_VERSION=3.8
+#PYTHON_LIB_PATH     = /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/$${PYTHON_VERSION}/lib/
+#PYTHON_INCLUDE_PATH = /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/$${PYTHON_VERSION}/Headers/
+
+#Windows does not have a python default


### PR DESCRIPTION
- add script and deps file to build the pynrcpp library on buildbot ub1604 
- this is needed to build  the latest version of Atena bot legacy that now uses the `nrpycpp` instead of `libpyqac`
